### PR TITLE
Add tag labels in discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ export ONLINE_API_TOKEN=xxxxxx
 
 Visit [http://server:8000/scw-sd](http://server:8000/scw-sd) – you should see JSON targets.
 
+Example response:
+
+```json
+[
+  {
+    "targets": ["203.0.113.1:9100"],
+    "labels": {
+      "server_id": "12345",
+      "tag_web": "1",
+      "tag_prod": "1"
+    }
+  }
+]
+```
+
 ---
 
 ## Prometheus config

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ type serverDetail struct {
 	Network struct {
 		IP []string `json:"ip"`
 	} `json:"network"`
+	Tags []string `json:"tags"`
 }
 
 type target struct {
@@ -85,9 +86,13 @@ func handleSD(w http.ResponseWriter, _ *http.Request) {
 		if len(detail.Network.IP) == 0 {
 			continue
 		}
+		labels := map[string]string{"server_id": sid}
+		for _, t := range detail.Tags {
+			labels["tag_"+t] = "1"
+		}
 		result = append(result, target{
 			Targets: []string{detail.Network.IP[0] + ":9100"},
-			Labels:  map[string]string{"server_id": sid},
+			Labels:  labels,
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -83,6 +83,11 @@ func handleSD(w http.ResponseWriter, _ *http.Request) {
 			log.Printf("warn: %v", err)
 			continue
 		}
+		if len(detail.Tags) == 0 {
+			if err := apiGET(detailPath+"/tags", &detail.Tags); err != nil {
+				log.Printf("warn: %v", err)
+			}
+		}
 		if len(detail.Network.IP) == 0 {
 			continue
 		}


### PR DESCRIPTION
## Summary
- support `tags` field from the Online API
- include server tags as `tag_*` labels in emitted targets
- document example response including tags

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_686043ade4ac83209b4741369d95220b