### PR TITLE
Add Dockerfile with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# syntax=docker/dockerfile:1
+
+# --- Builder stage ---
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod main.go ./
+RUN go mod download
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /app/scw_sd main.go
+
+# --- Runtime stage ---
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates
+COPY --from=build /app/scw_sd /usr/local/bin/scw_sd
+EXPOSE 8000
+ENTRYPOINT ["/usr/local/bin/scw_sd"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that builds `scw_sd` in a builder stage and installs it in a minimal runtime image
- use Alpine base images with ca-certificates

No `.gitignore` updates were needed since build artifacts are already excluded.

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6860e37fb87883209515255abad67137